### PR TITLE
Fix windows temp dir removal test

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -163,17 +163,17 @@ func TestResolveTargetEvents_NoEventsDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
-	defer func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Errorf("Failed to restore directory: %v", err)
-		}
-	}()
 
 	tmpDir, err := os.MkdirTemp("", "gzcli-no-events-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer func() {
+		// Change back to original directory first (required on Windows)
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("Failed to restore directory: %v", err)
+		}
+		// Now we can remove the temp directory
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("Failed to remove temp dir: %v", err)
 		}
@@ -195,17 +195,17 @@ func TestResolveTargetEvents_EmptyEventsDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
-	defer func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Errorf("Failed to restore directory: %v", err)
-		}
-	}()
 
 	tmpDir, err := os.MkdirTemp("", "gzcli-empty-events-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer func() {
+		// Change back to original directory first (required on Windows)
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("Failed to restore directory: %v", err)
+		}
+		// Now we can remove the temp directory
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Errorf("Failed to remove temp dir: %v", err)
 		}


### PR DESCRIPTION
## Description

This PR fixes a Windows-specific issue in `TestResolveTargetEvents_NoEventsDirectory` and `TestResolveTargetEvents_EmptyEventsDirectory` where temporary directories could not be removed due to file locks. On Windows, changing the working directory using `os.Chdir()` locks the directory, preventing its deletion while the process is still inside it.

The fix reorders the cleanup operations to ensure the working directory is changed back to the original path *before* attempting to remove the temporary directory, releasing the lock.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD or build changes

## Related Issue

Closes #

## Changes Made

-   Combined the `os.Chdir(originalDir)` and `os.RemoveAll(tmpDir)` cleanup operations into a single `defer` function.
-   Ensured that `os.Chdir(originalDir)` is called *before* `os.RemoveAll(tmpDir)` within the deferred function.
-   Applied this fix to both `TestResolveTargetEvents_NoEventsDirectory` and `TestResolveTargetEvents_EmptyEventsDirectory`.

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have tested this on multiple platforms (if applicable) - specifically targeting Windows.

### Test Commands Run

```bash
# List commands used to test
go test ./...
```

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG (if applicable)
- [x] My code includes appropriate comments, especially in hard-to-understand areas

## Code Quality

- [x] My code follows the project's style guidelines
- [x] I have run `make fmt` to format my code
- [x] I have run `make lint` and fixed any issues
- [x] I have run `make vet` with no issues
- [x] I have reviewed my own code

## Breaking Changes

N/A

## Screenshots (if applicable)

## Additional Notes

This fix specifically addresses the `The process cannot access the file because it is being used by another process.` error encountered on Windows CI environments during test cleanup.

## Checklist

- [x] My commits follow the conventional commit format
- [ ] I have rebased my branch on the latest main
- [x] I have tested my changes thoroughly
- [ ] All CI checks pass

---
<a href="https://cursor.com/background-agent?bcId=bc-bf56ece7-6274-42fe-b159-e1271debe625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf56ece7-6274-42fe-b159-e1271debe625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

